### PR TITLE
Replace disabled stderr redirection char ^ with 2>

### DIFF
--- a/fish_prompt.fish
+++ b/fish_prompt.fish
@@ -1,8 +1,8 @@
 function git_status
   set -l dirty            "✖"
   set -l none             "✔"
-  set -l error_color      (set_color $fish_color_error ^/dev/null; or set_color red --bold)
-  set -l success_color    (set_color $fish_color_cwd ^/dev/null; or set_color green)
+  set -l error_color      (set_color $fish_color_error 2>/dev/null; or set_color red --bold)
+  set -l success_color    (set_color $fish_color_cwd 2>/dev/null; or set_color green)
   if git_is_repo
     if git_is_touched
       echo -ns "$error_color$dirty$reset_color "
@@ -23,7 +23,7 @@ function dir
 
   if git_is_repo
     if test "$theme_short_path" = 'yes'
-      set root_folder (command git rev-parse --show-toplevel ^/dev/null)
+      set root_folder (command git rev-parse --show-toplevel 2>/dev/null)
       set parent_root_folder (dirname $root_folder)
       set cwd (echo $PWD | sed -e "s|$parent_root_folder/||")
     end


### PR DESCRIPTION
Since [Fish 3.3.0][1], redirection to standard error with the `^` character has been disabled by default.

Reference: [oh-my-fish/oh-my-fish#585][2]

p.s.: this is the result of an automated process. Apologies if there is already another pull request that addresses this issue.

[1]: https://github.com/fish-shell/fish-shell/blob/master/CHANGELOG.rst#deprecations-and-removed-features-1
[2]: https://github.com/oh-my-fish/oh-my-fish/issues/585
